### PR TITLE
minor variable null check for preventing browser warning

### DIFF
--- a/Resources/public/js/history.js
+++ b/Resources/public/js/history.js
@@ -12,15 +12,16 @@ var parent = document.querySelector('#logHistory'),
 });
 
 //on button click load related data
-loadMoreBtn.addEventListener('click', function(){
-    [].forEach.call(document.querySelectorAll('.' + hiddenClass), function(item, idx){
-        console.log(item);
-        if (idx < maxItems) {
-            item.classList.remove(hiddenClass);
-        }
-        if ( document.querySelectorAll('.' + hiddenClass).length === 0) {
-            //if all items exposed hide load more button button
-            loadMoreBtn.style.display = 'none';
-        }
+if(loadMoreBtn !== null){
+    loadMoreBtn.addEventListener('click', function(){
+        [].forEach.call(document.querySelectorAll('.' + hiddenClass), function(item, idx){
+            console.log(item);
+            if (idx < maxItems) {
+                item.classList.remove(hiddenClass);
+            }
+            if ( document.querySelectorAll('.' + hiddenClass).length === 0) {
+                loadMoreBtn.style.display = 'none';
+            }
+        });
     });
-});
+}


### PR DESCRIPTION
```
history.js:13 Uncaught TypeError: Cannot read property 'addEventListener' of null
```